### PR TITLE
fix: correct exit(0), and remove as cast in consteval

### DIFF
--- a/semantic-2/src/comprehensive29/comprehensive29.rx
+++ b/semantic-2/src/comprehensive29/comprehensive29.rx
@@ -176,7 +176,7 @@ fn fetch_decode_execute(
     halt: &mut bool,
 ) {
     while ((*halt) == false) {
-        if (((*pc) < 0 || (*pc) >= MEMORY_SIZE)) {
+        if ((*pc) < 0 || (*pc) >= MEMORY_SIZE) {
             *halt = true;
         }
         if ((*halt) == true) {
@@ -203,9 +203,9 @@ fn fetch_decode_execute(
                 let r_src: i32 = memory[*pc as usize + 1];
                 let res: i32 = registers[r_dst as usize] + registers[r_src as usize];
                 // Simplified overflow check
-                if ((registers[r_dst as usize] > 0 && registers[r_src as usize] > 0 && res < 0)) {
+                if (registers[r_dst as usize] > 0 && registers[r_src as usize] > 0 && res < 0) {
                     *cf = true;
-                } else if ((registers[r_dst as usize] < 0 && registers[r_src as usize] < 0 && res > 0)) {
+                } else if (registers[r_dst as usize] < 0 && registers[r_src as usize] < 0 && res > 0) {
                     *cf = true;
                 } else {
                     *cf = false;
@@ -237,7 +237,7 @@ fn fetch_decode_execute(
             } else if (opcode == 6) { // DIV
                 let r_dst: i32 = memory[*pc as usize];
                 let r_src: i32 = memory[*pc as usize + 1];
-                if ((registers[r_src as usize] != 0)) {
+                if (registers[r_src as usize] != 0) {
                     registers[r_dst as usize] = registers[r_dst as usize] / registers[r_src as usize];
                 } else {
                     *halt = true; // Division by zero

--- a/semantic-2/src/comprehensive30/comprehensive30.rx
+++ b/semantic-2/src/comprehensive30/comprehensive30.rx
@@ -89,6 +89,8 @@ fn main() {
     }
 
     printlnInt(9999);
+
+    exit(0);
 }
 
 fn init_heap(heap: &mut [i32; HEAP_SIZE], free_list_head: &mut i32) {
@@ -351,5 +353,4 @@ fn another_level_of_scope() {
 
     let temp_ptr_for_error: i32 = my_malloc(&mut heap, &mut free_list_head, 1);
     my_free(&mut heap, &mut free_list_head, temp_ptr_for_error);
-    exit(0);
 }

--- a/semantic-2/src/comprehensive34/comprehensive34.rx
+++ b/semantic-2/src/comprehensive34/comprehensive34.rx
@@ -23,6 +23,7 @@ Conditional logic for node processing based on type and value.
 // - Conditional logic for node processing based on type and value.
 
 const NODE_POOL_SIZE: i32 = 512;
+const NODE_POOL_USIZE: usize = 512;
 const NODE_SIZE: i32 = 4;
 
 const TYPE_INTERNAL: i32 = 1;
@@ -36,14 +37,14 @@ struct Node {
 }
 
 struct Tree {
-    pool: [Node; NODE_POOL_SIZE as usize],
+    pool: [Node; NODE_POOL_USIZE],
     root: i32,
     next_free: i32,
 }
 
 fn main() {
     let mut tree: Tree = Tree {
-        pool: [Node { node_type: 0, value: 0, left: -1, right: -1 }; NODE_POOL_SIZE as usize],
+        pool: [Node { node_type: 0, value: 0, left: -1, right: -1 }; NODE_POOL_USIZE],
         root: -1,
         next_free: 0,
     };
@@ -84,7 +85,7 @@ fn initialize_pool(tree: &mut Tree) {
         tree.pool[i as usize].left = i + 1;
         i = i + 1;
     }
-    tree.pool[NODE_POOL_SIZE as usize - 1].left = -1;
+    tree.pool[NODE_POOL_USIZE - 1].left = -1;
     tree.next_free = 0;
 }
 
@@ -244,7 +245,7 @@ fn free_tree(tree: &mut Tree, node_idx: i32) {
 
 fn another_tree_operation() {
     let mut tree: Tree = Tree {
-        pool: [Node { node_type: 0, value: 0, left: -1, right: -1 }; NODE_POOL_SIZE as usize],
+        pool: [Node { node_type: 0, value: 0, left: -1, right: -1 }; NODE_POOL_USIZE],
         root: -1,
         next_free: 0,
     };
@@ -258,7 +259,7 @@ fn another_tree_operation() {
 
 fn yet_another_scenario() {
     let mut tree: Tree = Tree {
-        pool: [Node { node_type: 0, value: 0, left: -1, right: -1 }; NODE_POOL_SIZE as usize],
+        pool: [Node { node_type: 0, value: 0, left: -1, right: -1 }; NODE_POOL_USIZE],
         root: -1,
         next_free: 0,
     };


### PR DESCRIPTION
* Removed unnecessary parentheses in conditional expressions within the `fetch_decode_execute` function in `comprehensive29.rx`. [[1]](diffhunk://#diff-13d2d03e6d589fae4caa63f9da4c27978eb1d8c3457eec911aa974ee4bf53095L179-R179) [[2]](diffhunk://#diff-13d2d03e6d589fae4caa63f9da4c27978eb1d8c3457eec911aa974ee4bf53095L206-R208) [[3]](diffhunk://#diff-13d2d03e6d589fae4caa63f9da4c27978eb1d8c3457eec911aa974ee4bf53095L240-R240)

* Corrected the position of `exit(0);`  in `comprehensive30.rx`. [[1]](diffhunk://#diff-26b1a9cc8bd73178c97658553f58085c2e85cb1ec484b6effd196227b539d008R92-R93) [[2]](diffhunk://#diff-26b1a9cc8bd73178c97658553f58085c2e85cb1ec484b6effd196227b539d008L354)

*Removed as cast from Constant evaluation in `comprehensive34.rx` . [[1]](diffhunk://#diff-766bacbb902314ba7afa2ce5bbd2183c536fd6cdf5263702b461212986399cafR26) [[2]](diffhunk://#diff-766bacbb902314ba7afa2ce5bbd2183c536fd6cdf5263702b461212986399cafL39-R47) [[3]](diffhunk://#diff-766bacbb902314ba7afa2ce5bbd2183c536fd6cdf5263702b461212986399cafL87-R88) [[4]](diffhunk://#diff-766bacbb902314ba7afa2ce5bbd2183c536fd6cdf5263702b461212986399cafL247-R248) [[5]](diffhunk://#diff-766bacbb902314ba7afa2ce5bbd2183c536fd6cdf5263702b461212986399cafL261-R262)